### PR TITLE
Cython inverse array

### DIFF
--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -102,7 +102,7 @@ from .. import (_CONVERTERS,
 from ..lib import util
 from ..lib.util import (cached, warn_if_not_unique,
                         unique_int_1d, unique_int_1d_unsorted,
-                        int_array_is_sorted, inverse_unique_unsorted_array
+                        int_array_is_sorted, inverse_unique_contiguous_1d_array
                         )
 from ..lib import distances
 from ..lib import transformations
@@ -822,7 +822,9 @@ class GroupBase(_MutableBase):
 
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
-            mask = inverse_unique_unsorted_array(self.ix, indices)
+            # self.ix must be contiguous for cython implementation.
+            # crashes on slices of atomgroups otherwise.
+            mask = inverse_unique_contiguous_1d_array(np.ascontiguousarray(self.ix), indices)
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/core/groups.py
+++ b/package/MDAnalysis/core/groups.py
@@ -102,7 +102,7 @@ from .. import (_CONVERTERS,
 from ..lib import util
 from ..lib.util import (cached, warn_if_not_unique,
                         unique_int_1d, unique_int_1d_unsorted,
-                        int_array_is_sorted
+                        int_array_is_sorted, inverse_unique_unsorted_array
                         )
 from ..lib import distances
 from ..lib import transformations
@@ -822,10 +822,7 @@ class GroupBase(_MutableBase):
 
         indices = unique_int_1d_unsorted(self.ix)
         if set_mask:
-            mask = np.zeros_like(self.ix)
-            for i, x in enumerate(indices):
-                values = np.where(self.ix == x)[0]
-                mask[values] = i
+            mask = inverse_unique_unsorted_array(self.ix, indices)
             self._unique_restore_mask = mask
 
         issorted = int_array_is_sorted(indices)

--- a/package/MDAnalysis/lib/_cutil.pyx
+++ b/package/MDAnalysis/lib/_cutil.pyx
@@ -37,8 +37,8 @@ from cython.operator cimport dereference as deref
 
 np.import_array()
 
-__all__ = ['unique_int_1d', 'make_whole', 'find_fragments',
-           '_sarrus_det_single', '_sarrus_det_multiple']
+__all__ = ['inverse_unique_unsorted_array', 'unique_int_1d', 'make_whole',
+	   'find_fragments', '_sarrus_det_single', '_sarrus_det_multiple']
 
 cdef extern from "calc_distances.h":
     ctypedef float coordinate[3]
@@ -47,6 +47,29 @@ cdef extern from "calc_distances.h":
 
 ctypedef cset[int] intset
 ctypedef cmap[int, intset] intmap
+
+
+@cython.boundscheck(False) # turn off bounds-checking for entire function 
+@cython.wraparound(False)  # turn off negative index wrapping for entire function 
+cdef np.intp_t[::1] _inverse_unique_unsorted_array(np.intp_t[::1] full_arr,
+                                          np.intp_t[::1] unique_arr,
+                                          np.intp_t[::1] mask):
+    cdef Py_ssize_t i = 0 
+    cdef Py_ssize_t j = 0
+    cdef int n_full = full_arr.shape[0]
+    cdef int n_unique = unique_arr.shape[0]
+
+    for i in range(n_unique):
+        for j in range(n_full):
+            if unique_arr[i] == full_arr[j]:
+                mask[j] = i 
+    return mask
+
+
+def inverse_unique_unsorted_array(np.intp_t[::1] full_arr, np.intp_t[::1] unique_arr):
+    cdef np.intp_t[::1] mask = np.empty(full_arr.shape[0], dtype=np.intp)
+    return np.array(_inverse_unique_unsorted_array(full_arr, unique_arr, mask))
+
 
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -214,7 +214,7 @@ from .picklable_file_io import pickle_open, bz2_pickle_open, gzip_pickle_open
 
 from ..exceptions import StreamWarning, DuplicateWarning
 try:
-    from ._cutil import unique_int_1d, inverse_unique_unsorted_array
+    from ._cutil import unique_int_1d, inverse_unique_contiguous_1d_array
 except ImportError:
     raise ImportError("MDAnalysis not installed properly. "
                       "This can happen if your C extensions "

--- a/package/MDAnalysis/lib/util.py
+++ b/package/MDAnalysis/lib/util.py
@@ -214,7 +214,7 @@ from .picklable_file_io import pickle_open, bz2_pickle_open, gzip_pickle_open
 
 from ..exceptions import StreamWarning, DuplicateWarning
 try:
-    from ._cutil import unique_int_1d
+    from ._cutil import unique_int_1d, inverse_unique_unsorted_array
 except ImportError:
     raise ImportError("MDAnalysis not installed properly. "
                       "This can happen if your C extensions "

--- a/testsuite/MDAnalysisTests/lib/test_cutil.py
+++ b/testsuite/MDAnalysisTests/lib/test_cutil.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from MDAnalysis.lib._cutil import (
-    unique_int_1d, find_fragments, _in2d,
+    unique_int_1d, find_fragments, _in2d, inverse_unique_unsorted_array,
 )
 
 
@@ -45,6 +45,26 @@ def test_unique_int_1d(values):
     assert type(res) == type(ref)
     assert res.dtype == ref.dtype
 
+@pytest.mark.parametrize('arrays', (
+    [],  # empty array
+    [1, 1, 1, 1, ],  # all identical
+    [2, 3, 5, 7, ],  # unique, sorted
+    [5, 2, 7, 3, ],  # unique, unsorted
+    [1, 2, 2, 4, 4, 6, ],  # duplicates, sorted
+    [1, 2, 2, 6, 4, 4, ],  # duplicates, unsorted
+))
+def test_inverse_unique_unsorted_array(arrays):
+    # Generate unique, unsorted arrays.
+    array = np.array(arrays, dtype=np.intp)
+    values, indices = np.unique(array, return_index=True)
+    unique_array = array[np.sort(indices)]
+    
+    inverse = inverse_unique_unsorted_array(array, unique_array)
+    ref = array
+    res = unique_array[inverse]
+    assert_equal(res, ref)
+    assert type(res) == type(ref)
+    assert res.dtype == ref.dtype
 
 @pytest.mark.parametrize('edges,ref', [
     ([[0, 1], [1, 2], [2, 3], [3, 4]],


### PR DESCRIPTION
Fixes #3387

Changes made in this Pull Request:
 - Added cython implementation of inverse of unsorted, unqiue array
 - Replaced python code in groups.py with new cython function
 - Added tests confirming inverse correctly maps unique array onto original


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
